### PR TITLE
Fix package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    },
-    "./storefront": {
-      "import": "./dist/storefront/index.js",
-      "require": "./dist/storefront/index.cjs"
+      "require": "./dist/index.js"
     },
     "./management": {
       "import": "./dist/management/index.js",
-      "require": "./dist/management/index.cjs"
+      "require": "./dist/management/index.js"
+    },
+    "./storefront": {
+      "import": "./dist/storefront/index.js",
+      "require": "./dist/storefront/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
The `package.json`'s `exports` field points `"require"` to `.cjs` files that don't exist in the build. The package is already built as CommonJS only, CJS files are under `.js` files.

This breaks TypeScript apps that cannot emit ESM and only output CJS files (like NestJS apps). The code is valid during development (using ESM syntax) but starts failing when built because the actual built files are in CJS, which reads the `"require"` field of the package (a non-existant `.cjs` file).

The package works fine in ESM projects, because ESM code will read the `"import"` field of the exports, which points to an existing `.js` files. Although ESM projects end up reading CJS, this is okay because ESM supports CJS (but not the other way around).

The fix is to simply point both ESM and CJS code to the same `index.js` files.

## Next steps

If you want to build for ESM as well, I suggest you take a look into replacing `tsc` with [`tsdown`](https://tsdown.dev/guide/) in your `build` script. It's fairly easy to setup and typically bundles better than raw `tsc`. However, with the default configuration, the outputted file structure is not as verbose as `tsc`. So this would probably break projects (like mine) that actually traverse the package to grab types, since they're not currently exported at the root:

```ts
// This would no longer work under `tsdown`, because `tsdown` emits single tree-shakeable files to optimize bundles
import type { Storefront } from "@ywwa/paylater/dist/generated";
```